### PR TITLE
add contact type to distributor role

### DIFF
--- a/ArcGIS2InPort.xsl
+++ b/ArcGIS2InPort.xsl
@@ -307,6 +307,7 @@
 				<xsl:for-each select="/metadata/distInfo/distributor/distorCont">
 					<support-role>
 						<support-role-type>Distributor</support-role-type>
+						<contact-type>Organization</contact-type>
 						<from-date><xsl:value-of select="substring-before($defaultEffectiveDate,'T')"/></from-date>	
 						<xsl:choose>
 							<xsl:when test="rpOrgName">


### PR DESCRIPTION
contact-type tag was missing from Distributor support-role-type.